### PR TITLE
Set 'type' property first. Fixes #3

### DIFF
--- a/lib/dome.js
+++ b/lib/dome.js
@@ -177,6 +177,11 @@ var dome = (function (C) {
         var name, mapper;
         properties = properties || {};
 
+        if (properties.hasOwnProperty('type')) {
+            element.type = properties.type;
+            delete properties.type;
+        }
+
         for (name in properties) {
             if (properties.hasOwnProperty(name)) {
                 mapper = propmap[name];

--- a/test/el-test.js
+++ b/test/el-test.js
@@ -36,6 +36,13 @@ buster.testCase("Element", {
             dome.setProp({ data: { something: "hey" } }, el);
 
             assert.equals(el.getAttribute("data-something"), "hey");
+        },
+
+        "sets type before value": function () {
+            var el = document.createElement("input");
+            dome.setProp({ value: "yo", type: "radio" }, el);
+
+            assert.equals(el.getAttribute("value"), "yo");
         }
     },
 


### PR DESCRIPTION
A simple fix. Test passes in Opera (and Chrome and Firefox and IE9).
