### PR TITLE
Make byClass work as expected with PhantomJS

### DIFF
--- a/lib/dome.js
+++ b/lib/dome.js
@@ -24,7 +24,12 @@ var dome = (function (C) {
     function byClass(className, parent) {
         var ctx = parent || document;
         if (ctx.getElementsByClassName) {
-            return ctx.getElementsByClassName(className);
+            var elementsByClass = ctx.getElementsByClassName(className);
+
+            // PhantomJS (at least v1.9.2) might return a function. Weird.
+            if (typeof elementsByClass !== 'function') {
+                return elementsByClass;
+            }
         }
         var elements = ctx.getElementsByTagName("*"), i, l, result = [];
         var regexp = new RegExp("(^|\\s)" + className + "(\\s|$)");


### PR DESCRIPTION
getElementsByClassName() may return a function when running under PhantomJS, while this is not the case with Safari or Firefox.
