### PR TITLE
Using window instead of this.

### DIFF
--- a/lib/dome.js
+++ b/lib/dome.js
@@ -273,7 +273,7 @@ var dome = (function (C) {
         uuid: uuid,
         contains: contains
     };
-}(this.cull));
+}(window.cull));
 
 if (typeof require === "function" && typeof module === "object") {
     module.exports = dome;


### PR DESCRIPTION
Using webpack, "this" becomes undefined, and this.cull fails. Using window instead as a quick fix.

Not sure if this is the best solution, but it seems to work.